### PR TITLE
Fix stale serapay.io hosts and finish README secret docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Keep local notes and audit logs under `logs/`; the folder is ignored by git and 
 
 For production, `SESSION_SECRET` and `SERA_CONFIG_ENCRYPTION_KEY` must each be stable random values of at least 32 bytes. Generate each value separately:
 
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
 ## Scripts
 
 ```bash

--- a/client/src/pages/DeveloperPage.tsx
+++ b/client/src/pages/DeveloperPage.tsx
@@ -674,8 +674,8 @@ function EndpointRow({ ep, apiKey }: { ep: EndpointDef; apiKey: string }) {
   const [open, setOpen] = useState(false);
 
   const exampleCurl = ep.method === "GET"
-    ? `curl -H "x-api-key: ${apiKey}" \\\n  https://api.serapay.io${ep.path}`
-    : `curl -X ${ep.method} \\\n  -H "x-api-key: ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '{}' \\\n  https://api.serapay.io${ep.path}`;
+    ? `curl -H "x-api-key: ${apiKey}" \\\n  https://pay.sera.cx${ep.path}`
+    : `curl -X ${ep.method} \\\n  -H "x-api-key: ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '{}' \\\n  https://pay.sera.cx${ep.path}`;
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -797,7 +797,7 @@ export function Settings() {
                   >
                     <div className="rounded-lg overflow-hidden" style={{ background: qrBgColor || "#fff" }}>
                       <QRStyled
-                        value="https://serapay.io"
+                        value="https://pay.sera.cx"
                         size={68}
                         fgColor={qrFgColor}
                         bgColor={qrBgColor}
@@ -896,7 +896,7 @@ export function Settings() {
                     <QRStyled
                       value={profile?.walletAddress
                         ? buildClientAppUrl(`/?addr=${profile.walletAddress}&chainId=${paymentChainId}`)
-                        : "https://serapay.io"
+                        : "https://pay.sera.cx"
                       }
                       size={240}
                       fgColor={qrFgColor}


### PR DESCRIPTION
## Summary
- Replace leftover `serapay.io` / `api.serapay.io` examples with the live `pay.sera.cx` origin (developer curl samples + QR placeholders)
- Finish the truncated README instruction for generating `SESSION_SECRET` / `SERA_CONFIG_ENCRYPTION_KEY`

## Why
`pay.sera.cx` is the canonical production origin in code (`PRODUCTION_APP_ORIGIN`, CORS allowlists, tests). `serapay.io` / `api.serapay.io` no longer resolve; merchant API routes are served on the pay app host.

## Test plan
- [x] `pnpm run check`
- [x] `pnpm test` (42 passed, 1 skipped)
- [ ] Spot-check Developer page curl examples show `https://pay.sera.cx/...`
- [ ] Spot-check Settings QR preview fallback uses `https://pay.sera.cx`


Made with [Cursor](https://cursor.com)